### PR TITLE
Fix __sync_synchronize_dmb error

### DIFF
--- a/source/sync.s
+++ b/source/sync.s
@@ -1,0 +1,11 @@
+.syntax unified
+.arch armv6k
+.arm
+.global __sync_synchronize_dmb
+.global __dmb
+
+__dmb:
+__sync_synchronize_dmb:
+	mov r0, #0
+	mcr p15, 0, r0, c7, c10, 5
+	bx lr


### PR DESCRIPTION
This uses code from https://github.com/ZeroSkill1/3ds_am, which is licensed as Unlicense.  Fixes #4